### PR TITLE
Update OCI Secrets Store CSI Driver image repository

### DIFF
--- a/charts/oci-secrets-store-csi-driver-provider/values.yaml
+++ b/charts/oci-secrets-store-csi-driver-provider/values.yaml
@@ -10,7 +10,7 @@
 provider:
   # Provider image settings
   image:
-    repository: oci-secrets-store-csi-driver-provider
+    repository: ghcr.io/oracle/oci-secrets-store-csi-driver-provider
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""


### PR DESCRIPTION
k8s 1.34 doesn't accept unnamed repos anymore, need actual domain